### PR TITLE
fix(code): babel-polyfill related bug

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,9 @@ var exec = require('child_process').exec;
 var spawnSync = require('child_process').spawnSync;
 var execSync = require('child_process').execSync;
 var os = require('os');
-require('babel-polyfill');
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
 
 var defaultOptions = {
   onBuildStart: {

--- a/src/webpack-shell-plugin.js
+++ b/src/webpack-shell-plugin.js
@@ -3,7 +3,9 @@ const exec = require('child_process').exec;
 const spawnSync = require('child_process').spawnSync;
 const execSync = require('child_process').execSync;
 const os = require('os');
-require('babel-polyfill');
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
 
 const defaultOptions = {
   onBuildStart: {


### PR DESCRIPTION
It’s not recommended to use babel-polyfill in a tool, see:
https://babeljs.io/docs/usage/polyfill/

`babel-polyfill` only allows a single instance to be loaded.

If you run webpack with `babel-node`, this causes the plugin to throw an error. This simple fix simply prevent `babel-polyfill` being loaded if it has previously been loaded into the environment.